### PR TITLE
Testing changes to listing profile

### DIFF
--- a/common/common_prez_profile.trig
+++ b/common/common_prez_profile.trig
@@ -11,6 +11,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix schema: <https://schema.org/> .
 @prefix tern: <https://w3id.org/tern/ontologies/tern/> .
+@prefix void: <http://rdfs.org/ns/void#> .
 
 <https://prez/profiles> {
     prez:BDRHumanFeatureProfile a
@@ -47,19 +48,18 @@
                                      ( geo:hasGeometry geo:asWKT )
                                      ( geo:hasDefaultGeometry geo:asWKT )
                                      ( schema:temporal shext:allPredicateValues )
-                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember rdf:type )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:usedProcedure )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember tern:resultDateTime )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:phenomenonTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] rdf:type )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:usedProcedure tern:methodType )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] tern:resultDateTime )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:phenomenonTime )
-                                     [ sh:inversePath rdfs:member ]
                                      ( [ sh:inversePath rdfs:member ] rdf:type )
                                      ( [ sh:inversePath rdfs:member ] schema:isPartOf )
-                                     [sh:inversePath schema:about]
                                      ( [sh:inversePath schema:about] rdfs:comment )
                                      ( [sh:inversePath schema:about] schema:identifier )
                                      ( [sh:inversePath schema:about] schema:isPartOf )
@@ -96,24 +96,61 @@
                                      ( geo:hasGeometry geo:asWKT )
                                      ( geo:hasDefaultGeometry geo:asWKT )
                                      ( schema:temporal shext:allPredicateValues )
-                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember rdf:type )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:hasSimpleResult )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:usedProcedure )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember tern:resultDateTime )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:phenomenonTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] rdf:type )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasSimpleResult )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:usedProcedure tern:methodType )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] tern:resultDateTime )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:phenomenonTime )
-                                     [ sh:inversePath rdfs:member ]
                                      ( [ sh:inversePath rdfs:member ] rdf:type )
                                      ( [ sh:inversePath rdfs:member ] schema:isPartOf )
-                                     [sh:inversePath schema:about]
                                      ( [sh:inversePath schema:about] rdfs:comment )
                                      ( [sh:inversePath schema:about] schema:identifier )
                                      ( [sh:inversePath schema:about] schema:isPartOf )
+                                 )
+                    ]
+            ] ;
+    .
+
+    prez:MinimalFeatureListingProfile a
+            prof:Profile,
+            sh:NodeShape,
+            prez:ListingProfile,
+            prez:ObjectProfile ;
+        dcterms:description "Fast and minimal profile for listing Features." ;
+        dcterms:identifier "feature-listing-minimal"^^xsd:token ;
+        dcterms:title "Feature Listing Minimal Profile" ;
+        altr-ext:constrainsClass
+            geo:Feature, rdfs:Resource , prez:CQLFilterResult , prez:SearchResult ;
+        altr-ext:hasDefaultResourceFormat "application/geo+json" ;
+        altr-ext:hasResourceFormat
+            "application/geo+json",
+            "application/anot+ld+json",
+            "application/ld+json",
+            "application/rdf+xml",
+            "text/anot+turtle",
+            "text/turtle" ;
+        sh:property
+            [
+                sh:path
+                    [
+                        sh:union (
+                                    rdf:type
+                                    schema:identifier
+                                    schema:isPartOf
+                                    void:inDataset
+                                    ( geo:hasGeometry geo:asWKT )
+                                    ( geo:hasDefaultGeometry geo:asWKT )
+                                    ( [ sh:inversePath rdfs:member ] rdf:type )
+                                    ( [ sh:inversePath rdfs:member ] schema:isPartOf )
+                                    ( [sh:inversePath schema:about] schema:identifier )
+                                    ( [sh:inversePath schema:about] schema:isPartOf )
                                  )
                     ]
             ] ;

--- a/common/common_prez_profile.trig
+++ b/common/common_prez_profile.trig
@@ -10,6 +10,7 @@
 @prefix shext: <http://example.com/shacl-extension#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix schema: <https://schema.org/> .
+@prefix tern: <https://w3id.org/tern/ontologies/tern/> .
 
 <https://prez/profiles> {
     prez:BDRHumanFeatureProfile a
@@ -46,14 +47,15 @@
                                      ( geo:hasGeometry geo:asWKT )
                                      ( geo:hasDefaultGeometry geo:asWKT )
                                      ( schema:temporal shext:allPredicateValues )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember sosa:hasSimpleResult )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember sosa:observedProperty )
-                                     ( sosa:isFeatureOfInterestOf sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember )
-                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:hasSimpleResult )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:observedProperty )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:usedProcedure )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember tern:resultDateTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:phenomenonTime )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:observedProperty )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:usedProcedure tern:methodType )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] tern:resultDateTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:phenomenonTime )
                                      [ sh:inversePath rdfs:member ]
                                      ( [ sh:inversePath rdfs:member ] rdf:type )
                                      ( [ sh:inversePath rdfs:member ] schema:isPartOf )
@@ -94,14 +96,17 @@
                                      ( geo:hasGeometry geo:asWKT )
                                      ( geo:hasDefaultGeometry geo:asWKT )
                                      ( schema:temporal shext:allPredicateValues )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember sosa:hasSimpleResult )
-                                     ( sosa:isFeatureOfInterestOf sosa:hasMember sosa:observedProperty )
-                                     ( sosa:isFeatureOfInterestOf sosa:observedProperty )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:hasSimpleResult )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:observedProperty )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:usedProcedure )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember tern:resultDateTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember sosa:phenomenonTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasSimpleResult )
                                      ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:observedProperty )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:usedProcedure tern:methodType )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] tern:resultDateTime )
+                                     ( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:phenomenonTime )
                                      [ sh:inversePath rdfs:member ]
                                      ( [ sh:inversePath rdfs:member ] rdf:type )
                                      ( [ sh:inversePath rdfs:member ] schema:isPartOf )


### PR DESCRIPTION
This adds some extra properties such as usedProcedure, resultDatetime, phenomenonTime, that users are missing in the listing responses' GeoJSON properties.
Also, this removes the sosa:isFeatureOfInterestOf path. There are no contributors that use that, so we don't need to follow it.

@recalcitrantsupplant Can you please set up a testing Prez API somewhere we can test the performance impact this has (if any)?

Question:

With many of these property paths that start with the same pattern, eg:
```
( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember <property1> )
( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember <property2> )
( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember <property3> )
```
Does this become inefficient? Does it generate extra unions with extra variables for the first part and second part duplicated many times?
Would it be better to allow something like:
```
( [ sh:inversePath sosa:hasFeatureOfInterest ] sosa:hasMember [ sh:alternativePath (<property1> <property2> <property3>) ] )
```