### PR TITLE
class changes in endpoint definitions

### DIFF
--- a/common/common_prez_custom_endpoints.trig
+++ b/common/common_prez_custom_endpoints.trig
@@ -1,150 +1,120 @@
+@prefix sdo: <https://schema.org/> .
+@prefix prez: <https://prez.dev/ont/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix schema: <https://schema.org/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix abis: <https://linked.data.gov.au/def/abis/> .
+@prefix ogc: <http://www.opengis.net/ogcapi-features-1/1.0/> .
+@prefix ex: <http://example.org/ns#> .
+
 <https://prez/custom-endpoints> {
 
-  <http://example.org/catalogs-listing> a <https://prez.dev/ont/DynamicEndpoint>, <https://prez.dev/ont/ListingEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Catalogs Listing";
-    <https://prez.dev/ont/apiPath> "/catalogs";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL1> .
+  ex:catalogs-listing a prez:DynamicEndpoint, prez:ListingEndpoint ;
+    rdfs:label "Catalogs Listing" ;
+    prez:apiPath "/catalogs" ;
+    prez:relevantShapes ex:shape-R0-HL1 .
 
-  <http://example.org/catalogs-object> a <https://prez.dev/ont/DynamicEndpoint>, <https://prez.dev/ont/ObjectEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Catalogs Object";
-    <https://prez.dev/ont/apiPath> "/catalogs/{catalogId}";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL1> .
+  ex:catalogs-object a prez:DynamicEndpoint, prez:ObjectEndpoint ;
+    rdfs:label "Catalogs Object" ;
+    prez:apiPath "/catalogs/{catalogId}" ;
+    prez:relevantShapes ex:shape-R0-HL1 .
 
-  <http://example.org/collections-listing> a <https://prez.dev/ont/DynamicEndpoint>,
-      <https://prez.dev/ont/ListingEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Collections Listing";
-    <https://prez.dev/ont/apiPath> "/catalogs/{catalogId}/collections";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL2> .
+  ex:collections-listing a prez:DynamicEndpoint, prez:ListingEndpoint ;
+    rdfs:label "Collections Listing" ;
+    prez:apiPath "/catalogs/{catalogId}/collections" ;
+    prez:relevantShapes ex:shape-R0-HL2 .
 
-  <http://example.org/collections-object> a <https://prez.dev/ont/DynamicEndpoint>,
-      <https://prez.dev/ont/ObjectEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Collections Object";
-    <https://prez.dev/ont/apiPath> "/catalogs/{catalogId}/collections/{recordsCollectionId}";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL2> .
+  ex:collections-object a prez:DynamicEndpoint, prez:ObjectEndpoint ;
+    rdfs:label "Collections Object" ;
+    prez:apiPath "/catalogs/{catalogId}/collections/{recordsCollectionId}" ;
+    prez:relevantShapes ex:shape-R0-HL2 .
 
-  <http://example.org/items-listing> a <https://prez.dev/ont/DynamicEndpoint>, <https://prez.dev/ont/ListingEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Items Listing";
-    <https://prez.dev/ont/apiPath> "/catalogs/{catalogId}/collections/{recordsCollectionId}/items";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL3> .
+  ex:items-listing a prez:DynamicEndpoint, prez:ListingEndpoint ;
+    rdfs:label "Items Listing" ;
+    prez:apiPath "/catalogs/{catalogId}/collections/{recordsCollectionId}/items" ;
+    prez:relevantShapes ex:shape-R0-HL3 .
 
-  <http://example.org/items-object> a <https://prez.dev/ont/DynamicEndpoint>, <https://prez.dev/ont/ObjectEndpoint>;
-    <http://www.w3.org/2000/01/rdf-schema#label> "Items Object";
-    <https://prez.dev/ont/apiPath> "/catalogs/{catalogId}/collections/{recordsCollectionId}/items/{itemId}";
-    <https://prez.dev/ont/relevantShapes> <http://example.org/shape-R0-HL3> .
+  ex:items-object a prez:DynamicEndpoint, prez:ObjectEndpoint ;
+    rdfs:label "Items Object" ;
+    prez:apiPath "/catalogs/{catalogId}/collections/{recordsCollectionId}/items/{itemId}" ;
+    prez:relevantShapes ex:shape-R0-HL3 .
 
-  <http://example.org/ns#Feature> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#property> _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-016F734670120337BB70DAF792927957,
-      _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-F0F050183A03097C4A981516BB424AB4;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.opengis.net/ont/geosparql#Feature>;
-    <https://prez.dev/ont/hierarchyLevel> 2 .
+    ex:shape-R0-HL1 a sh:NodeShape ;
+    sh:targetClass dcat:Catalog , sdo:DataCatalog ;
+    prez:hierarchyLevel 1 ;
+    sh:property [
+      sh:path [ sh:alternativePath ( [ sh:inversePath dcterms:isPartOf ] dcterms:hasPart [ sh:inversePath sdo:isPartOf ] sdo:hasPart )] ;
+      sh:class schema:Dataset
+    ] .
 
-  <http://example.org/ns#FeatureCollections> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#property> _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-A094AE7594CDE1B2BA0F622C6B60F2A7;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.opengis.net/ont/geosparql#FeatureCollection>;
-    <https://prez.dev/ont/hierarchyLevel> 1 .
+  ex:shape-R0-HL2 a sh:NodeShape ;
+    sh:targetClass schema:Dataset ;
+    prez:hierarchyLevel 2 ;
+    sh:property [
+      sh:path [ sh:alternativePath ( [ sh:inversePath dcterms:hasPart ] dcterms:isPartOf [ sh:inversePath sdo:hasPart ] sdo:isPartOf )] ;
+      sh:or ( [ sh:class dcat:Catalog ] [sh:class sdo:DataCatalog] )
+    ] .
 
-  <http://example.org/ns#Object> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <https://prez.dev/ont/hierarchyLevel> 1 .
+  ex:shape-R0-HL3 a sh:NodeShape ;
+    sh:targetClass abis:BiodiversityRecord ;
+    prez:hierarchyLevel 3 ;
+    sh:property [
+      sh:path schema:isPartOf ;
+      sh:class schema:Dataset
+    ] , [
+      sh:path ( schema:isPartOf [ sh:alternativePath ( [ sh:inversePath dcterms:hasPart ] dcterms:isPartOf [ sh:inversePath sdo:hasPart ] sdo:isPartOf ) ] ) ;
+      sh:or ( [ sh:class dcat:Catalog ] [sh:class sdo:DataCatalog] )
+    ] .
 
-  <http://example.org/ns#QueryablesGlobal> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.opengis.net/ont/geosparql#Feature>;
-    <https://prez.dev/ont/hierarchyLevel> 1 .
+  ogc:feature a prez:OGCFeaturesEndpoint, prez:ObjectEndpoint ;
+    prez:relevantShapes ex:Feature .
 
-  <http://example.org/ns#QueryablesLocal> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.opengis.net/ont/geosparql#Feature>;
-    <https://prez.dev/ont/hierarchyLevel> 2 .
+  ogc:feature-collection a prez:OGCFeaturesEndpoint, prez:ObjectEndpoint ;
+    prez:relevantShapes ex:FeatureCollections .
 
-  <http://example.org/shape-R0-HL1> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#property> _:node2852;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.w3.org/ns/dcat#Catalog>;
-    <https://prez.dev/ont/hierarchyLevel> 1 .
+  ogc:feature-collections a prez:ListingEndpoint, prez:OGCFeaturesEndpoint ;
+    prez:relevantShapes ex:FeatureCollections .
 
-  <http://example.org/shape-R0-HL2> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#property> _:node2855;
-    <http://www.w3.org/ns/shacl#targetClass> <http://www.w3.org/ns/dcat#Dataset>;
-    <https://prez.dev/ont/hierarchyLevel> 2 .
+  ogc:features a prez:ListingEndpoint, prez:OGCFeaturesEndpoint ;
+    prez:relevantShapes ex:Feature .
 
-  <http://example.org/shape-R0-HL3> a <http://www.w3.org/ns/shacl#NodeShape>;
-    <http://www.w3.org/ns/shacl#property> _:node2857, _:node2858;
-    <http://www.w3.org/ns/shacl#targetClass> <https://linked.data.gov.au/def/abis/BiodiversityRecord>;
-    <https://prez.dev/ont/hierarchyLevel> 3 .
+  ogc:queryables-global a prez:ListingEndpoint, prez:OGCFeaturesEndpoint ;
+    prez:relevantShapes ex:QueryablesGlobal .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/feature> a <https://prez.dev/ont/OGCFeaturesEndpoint>,
-      <https://prez.dev/ont/ObjectEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#Feature> .
+  ogc:queryables-local a prez:ListingEndpoint, prez:OGCFeaturesEndpoint ;
+    prez:relevantShapes ex:QueryablesLocal .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/feature-collection> a <https://prez.dev/ont/OGCFeaturesEndpoint>,
-      <https://prez.dev/ont/ObjectEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#FeatureCollections> .
+  ex:Feature a sh:NodeShape ;
+    sh:targetClass geo:Feature ;
+    prez:hierarchyLevel 2 ;
+    sh:property [
+      sh:path [ sh:inversePath rdfs:member ] ;
+      sh:class geo:FeatureCollection
+    ] , [
+      sh:path ( [ sh:inversePath rdfs:member ] schema:isPartOf ) ;
+      sh:class schema:Dataset
+    ] .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/feature-collections> a <https://prez.dev/ont/ListingEndpoint>,
-      <https://prez.dev/ont/OGCFeaturesEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#FeatureCollections> .
+  ex:FeatureCollections a sh:NodeShape ;
+    sh:targetClass geo:FeatureCollection ;
+    prez:hierarchyLevel 1 ;
+    sh:property [
+      sh:path schema:isPartOf ;
+      sh:class schema:Dataset
+    ] .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/features> a <https://prez.dev/ont/ListingEndpoint>,
-      <https://prez.dev/ont/OGCFeaturesEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#Feature> .
+  ex:Object a sh:NodeShape ;
+    prez:hierarchyLevel 1 .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/queryables-global> a <https://prez.dev/ont/ListingEndpoint>,
-      <https://prez.dev/ont/OGCFeaturesEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#QueryablesGlobal> .
+  ex:QueryablesGlobal a sh:NodeShape ;
+    sh:targetClass geo:Feature ;
+    prez:hierarchyLevel 1 .
 
-  <http://www.opengis.net/ogcapi-features-1/1.0/queryables-local> a <https://prez.dev/ont/ListingEndpoint>,
-      <https://prez.dev/ont/OGCFeaturesEndpoint>;
-    <https://prez.dev/ont/relevantShapes> <http://example.org/ns#QueryablesLocal> .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-016F734670120337BB70DAF792927957 <http://www.w3.org/ns/shacl#class>
-      <http://www.opengis.net/ont/geosparql#FeatureCollection> ;
-    <http://www.w3.org/ns/shacl#path> _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-DD52B416D7E1B4277882CA4A639D77D7 .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-3C982ED45A0AEAAB2303F2A1CC965410 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
-      <https://schema.org/isPartOf> ;
-    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-40CC678D41086AB964C8878654DBD346 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
-      _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-4D4C7B2DC985DF78A54F6E80E833C19F ;
-    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
-      _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-3C982ED45A0AEAAB2303F2A1CC965410 .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-4D4C7B2DC985DF78A54F6E80E833C19F <http://www.w3.org/ns/shacl#inversePath>
-      <http://www.w3.org/2000/01/rdf-schema#member> .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-A094AE7594CDE1B2BA0F622C6B60F2A7 <http://www.w3.org/ns/shacl#class>
-      <http://www.w3.org/ns/dcat#Dataset> ;
-    <http://www.w3.org/ns/shacl#path> <https://schema.org/isPartOf> .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-DD52B416D7E1B4277882CA4A639D77D7 <http://www.w3.org/ns/shacl#inversePath>
-      <http://www.w3.org/2000/01/rdf-schema#member> .
-
-  _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-F0F050183A03097C4A981516BB424AB4 <http://www.w3.org/ns/shacl#class>
-      <http://www.w3.org/ns/dcat#Dataset> ;
-    <http://www.w3.org/ns/shacl#path> _:genid-838ab4f83f5c430891fcb52e38aa64fa490371-40CC678D41086AB964C8878654DBD346 .
-
-  _:node2852 <http://www.w3.org/ns/shacl#or> _:node2853;
-    <http://www.w3.org/ns/shacl#path> <http://purl.org/dc/terms/hasPart> .
-
-  _:node2853 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:node2854;
-    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-
-  _:node2854 <http://www.w3.org/ns/shacl#class> <http://www.w3.org/ns/dcat#Dataset> .
-
-  _:node2855 <http://www.w3.org/ns/shacl#class> <http://www.w3.org/ns/dcat#Catalog>;
-    <http://www.w3.org/ns/shacl#path> _:node2856 .
-
-  _:node2856 <http://www.w3.org/ns/shacl#inversePath> <http://purl.org/dc/terms/hasPart> .
-
-  _:node2857 <http://www.w3.org/ns/shacl#class> <http://www.w3.org/ns/dcat#Dataset>;
-    <http://www.w3.org/ns/shacl#path> <https://schema.org/isPartOf> .
-
-  _:node2858 <http://www.w3.org/ns/shacl#class> <http://www.w3.org/ns/dcat#Catalog>;
-    <http://www.w3.org/ns/shacl#path> _:node2859 .
-
-  _:node2859 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <https://schema.org/isPartOf>;
-    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:node2860 .
-
-  _:node2860 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> _:node2861;
-    <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
-
-  _:node2861 <http://www.w3.org/ns/shacl#inversePath> <http://purl.org/dc/terms/hasPart> .
+  ex:QueryablesLocal a sh:NodeShape ;
+    sh:targetClass geo:Feature ;
+    prez:hierarchyLevel 2 .
 
 }

--- a/minimal_testing_data/endpoints_testing.trig
+++ b/minimal_testing_data/endpoints_testing.trig
@@ -1,0 +1,73 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix schema: <https://schema.org/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix abis: <https://linked.data.gov.au/def/abis/> .
+@prefix ex: <http://example.org/data#> .
+
+<http://example.org/fake-data> {
+
+ex:fake-catalog1 a dcat:Catalog ;
+    rdfs:label "Fake Wildlife Data Catalog" ;
+    dcterms:hasPart ex:fake-dataset1, ex:fake-dataset2 .
+
+ex:fake-catalog2 a dcat:Catalog ;
+    rdfs:label "Fake Marine Biology Catalog" ;
+    dcterms:hasPart ex:fake-dataset3, ex:fake-dataset4 .
+
+ex:fake-dataset1 a schema:Dataset ;
+    rdfs:label "Fake Australian Bird Observations" ;
+    schema:isPartOf ex:fake-featurecollection1 .
+
+ex:fake-dataset2 a schema:Dataset ;
+    rdfs:label "Fake Native Plant Species Records" ;
+    schema:isPartOf ex:fake-featurecollection1 .
+
+ex:fake-dataset3 a schema:Dataset ;
+    rdfs:label "Fake Coral Reef Monitoring Data" ;
+    schema:isPartOf ex:fake-featurecollection2 .
+
+ex:fake-dataset4 a schema:Dataset ;
+    rdfs:label "Fake Fish Population Surveys" ;
+    schema:isPartOf ex:fake-featurecollection2 .
+
+ex:fake-featurecollection1 a geo:FeatureCollection ;
+    rdfs:label "Fake Terrestrial Biodiversity Collection" ;
+    schema:isPartOf ex:fake-dataset1 ;
+    rdfs:member ex:fake-feature1, ex:fake-feature2 .
+
+ex:fake-featurecollection2 a geo:FeatureCollection ;
+    rdfs:label "Fake Marine Biodiversity Collection" ;
+    schema:isPartOf ex:fake-dataset3 ;
+    rdfs:member ex:fake-feature3, ex:fake-feature4 .
+
+ex:fake-feature1 a geo:Feature ;
+    rdfs:label "Fake Kookaburra Observation Site 1" .
+
+ex:fake-feature2 a geo:Feature ;
+    rdfs:label "Fake Eucalyptus Grove Location" .
+
+ex:fake-feature3 a geo:Feature ;
+    rdfs:label "Fake Great Barrier Reef Station A" .
+
+ex:fake-feature4 a geo:Feature ;
+    rdfs:label "Fake Ningaloo Marine Park Point B" .
+
+ex:fake-record1 a abis:BiodiversityRecord ;
+    rdfs:label "Fake Kookaburra Sighting Record 2024-001" ;
+    schema:isPartOf ex:fake-dataset1 .
+
+ex:fake-record2 a abis:BiodiversityRecord ;
+    rdfs:label "Fake Red Gum Tree Census Record 2024-002" ;
+    schema:isPartOf ex:fake-dataset2 .
+
+ex:fake-record3 a abis:BiodiversityRecord ;
+    rdfs:label "Fake Coral Health Assessment 2024-003" ;
+    schema:isPartOf ex:fake-dataset3 .
+
+ex:fake-record4 a abis:BiodiversityRecord ;
+    rdfs:label "Fake Clownfish Population Count 2024-004" ;
+    schema:isPartOf ex:fake-dataset4 .
+
+}


### PR DESCRIPTION
1. refactor common endpoints to change genids -> blank nodes for readability.
2. add alternative paths / sh:or to support multiple classes/predicates at different levels. This is schema:DataCatalog at the top level and a change to schema:Dataset at the second level.

Apologies I intended to do this in two commits so you could see a diff of the profile with blank nodes -> class changes, but it's one commit here.

The endpoint changes worked correctly up to level three. Level three contained an alternate path within a sequence path. I have made code changes to prez to support this in this branch https://github.com/RDFLib/prez/tree/david/handle-alt-in-seq. While I am working on this area of the code I would like to try and simplify/refactor it a little more, and also introduce the FILTER EXISTS changes we previously discussed. I will try do this in the next day.

Subselect of queries using the prez branch above:

Level 1:
```sparql
SELECT DISTINCT ?focus_node
WHERE {
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?focus_classes .
?focus_node ^<http://purl.org/dc/terms/isPartOf>|<http://purl.org/dc/terms/hasPart>|^<https://schema.org/isPartOf>|<https://schema.org/hasPart> ?path_node_1 .
?path_node_1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Dataset>
VALUES ?focus_classes{ <https://schema.org/DataCatalog> <http://www.w3.org/ns/dcat#Catalog>  }
}LIMIT 10 OFFSET 0
```
Level 2:
```sparql
SELECT DISTINCT ?focus_node
WHERE {
<http://example.org/data#fake-catalog1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?path_node_classes_1 .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Dataset> .
?focus_node ^<http://purl.org/dc/terms/hasPart>|<http://purl.org/dc/terms/isPartOf>|^<https://schema.org/hasPart>|<https://schema.org/isPartOf> <http://example.org/data#fake-catalog1>
VALUES ?path_node_classes_1{ <http://www.w3.org/ns/dcat#Catalog> <https://schema.org/DataCatalog>  }
}LIMIT 10 OFFSET 0

```
Level 3:
```sparql
SELECT DISTINCT ?focus_node
WHERE {
<http://example.org/data#fake-catalog1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?path_node_classes_2 .
<http://example.org/data#fake-dataset1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Dataset> .
?focus_node <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://linked.data.gov.au/def/abis/BiodiversityRecord> .
?focus_node <https://schema.org/isPartOf> <http://example.org/data#fake-dataset1> .
?focus_node <https://schema.org/isPartOf>/(^<http://purl.org/dc/terms/hasPart>|<http://purl.org/dc/terms/isPartOf>|^<https://schema.org/hasPart>|<https://schema.org/isPartOf>) <http://example.org/data#fake-catalog1>
VALUES ?path_node_classes_2{ <http://www.w3.org/ns/dcat#Catalog> <https://schema.org/DataCatalog>  }
}LIMIT 10 OFFSET 0
```
Will put this in draft until Prez changes merged.