### PR TITLE
renaming for prod changes

### DIFF
--- a/merit-beta/merit_beta_prez_olis_config.trig
+++ b/merit-beta/merit_beta_prez_olis_config.trig
@@ -3,7 +3,11 @@
     <https://merit-sparql-endpoint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
             <https://olis.dev/VirtualSparqlEndpoint> ;
         <https://olis.dev/isAliasFor> <https://prez-system-vg> ;
+        <https://olis.dev/isAliasFor> <https://merit-data> ;
         <https://schema.org/name> "MERIT beta Virtual SPARQL Endpoint" .
+
+    <https://merit-data> a <https://olis.dev/VirtualGraph> ;
+        <https://schema.org/name> "MERIT Beta Virtual Graph" .
 
 }
 

--- a/merit-prod/merit_prod_prez_olis_config.trig
+++ b/merit-prod/merit_prod_prez_olis_config.trig
@@ -3,6 +3,10 @@
   <https://merit-sparql-endpoint> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
             <https://olis.dev/VirtualSparqlEndpoint> ;
     <https://olis.dev/isAliasFor> <https://prez-system-vg> ;
+    <https://olis.dev/isAliasFor> <https://merit-data> ;
     <https://schema.org/name> "MERIT Virtual SPARQL Endpoint" .
+
+    <https://merit-data> a <https://olis.dev/VirtualGraph> ;
+        <https://schema.org/name> "MERIT Prod Virtual Graph" .
 
 }


### PR DESCRIPTION
1. rename merit -> merit prod
2. explicitly create in this repo the `https://merit-data` virtual graph which presumably was created outside this repo previously and includes the relevant instance data.